### PR TITLE
Updated some links to deprecated forums, updated to discourse.kohanafram...

### DIFF
--- a/application/templates/home/social.mustache
+++ b/application/templates/home/social.mustache
@@ -4,7 +4,7 @@
 		<h2>Community</h2>
 		<ul>
 			<li>
-				<a href="http://forum.kohanaframework.org" id="forum" class="icon">
+				<a href="http://discourse.kohanaframework.org" id="forum" class="icon">
 					<h3>Forum</h3>
 					Official announcements, community support, and feedback.
 				</a>

--- a/application/templates/home/whouses.mustache
+++ b/application/templates/home/whouses.mustache
@@ -8,5 +8,5 @@
 		<img src="{{base_url}}assets/img/gallery/logos/nationalgeographic.png" width="280" height="100" alt="National Geographic" />
 		<img src="{{base_url}}assets/img/gallery/logos/zepol-ti.png" width="280" height="100" alt="Zepol-Ti" />
 	</div>
-	<p>These are some of the people already using Kohana. <a href="http://forum.kohanaframework.org">See more on the Forums.</a></p>
+	<p>These are some of the people already using Kohana. <a href="http://discourse.kohanaframework.org">See more on the Forums.</a></p>
 </section> <!-- END section#who -->


### PR DESCRIPTION
The homepage of http://www.kohanaframework.org has a link to the old forums. When you get there, there's a notice at the top saying that people should go to the updated forums. This just fixes those links.
